### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Create a workflow (eg: `.github/workflows/team-labeler.yml` see [Creating a Work
 This action only needs the GITHUB_TOKEN secret as it interacts with the GitHub API to modify labels. The action can be used as such:
 
 ```yaml
-on: pull-request
+on: pull_request
 name: team-label
 jobs:
   team-labeler:


### PR DESCRIPTION
Hi there!

Thanks alot for this, trying it out now!

Just noticed after copy pasting from the example in the readme, that you actually need to specify pull_request and not pull-request. The latter gives an error in github actions.

Thanks again!