### PR TITLE
Add possibility to add labels based on GitHub team membership

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ You need to provide a yml file that contains members of your teams:
 LightSide:
   - '@Yoda'
   - '@Luke'
+  - '@RebelAlliance/jedi'
 
 DarkSide:
   - '@DarkVador'
@@ -35,7 +36,8 @@ DarkSide:
 ### Create `.github/workflows/team-labeler.yml`
 
 Create a workflow (eg: `.github/workflows/team-labeler.yml` see [Creating a Workflow file](https://help.github.com/en/articles/configuring-a-workflow#creating-a-workflow-file)) to utilize the labeler action.
-This action only needs the GITHUB_TOKEN secret as it interacts with the GitHub API to modify labels. The action can be used as such:
+This action only needs the GITHUB_TOKEN secret as it interacts with the GitHub API to modify labels. If you want to create labels based on GitHub team memberships, the GITHUB_TOKEN should be a PAT that can read GitHub teams (`read:org`).
+The action can be used as such:
 
 ```yaml
 on: pull_request

--- a/src/github.ts
+++ b/src/github.ts
@@ -19,6 +19,25 @@ export function getPrAuthor(): string | undefined {
   return pullRequest.user.login
 }
 
+export async function isUserMemberOfTeam(
+  client: github.GitHub,
+  org: string,
+  teamSlug: string,
+  username: string
+): Promise<boolean> {
+  const response = await client.teams.getMembershipInOrg({
+    org: org,
+    team_slug: teamSlug,
+    username: username
+  })
+
+  if (response.status === 200) {
+    return response.data.state === 'active'
+  } else {
+    return false
+  }
+}
+
 export async function getLabelsConfiguration(
   client: github.GitHub,
   configurationPath: string

--- a/src/main.ts
+++ b/src/main.ts
@@ -26,12 +26,14 @@ async function run() {
     }
 
     const client = createClient(token)
-    const labelsConfiguration: Map<
-      string,
-      string[]
-    > = await getLabelsConfiguration(client, configPath)
+    const labelsConfiguration: Map<string, string[]> =
+      await getLabelsConfiguration(client, configPath)
 
-    const labels: string[] = getTeamLabel(labelsConfiguration, `@${author}`)
+    const labels: string[] = await getTeamLabel(
+      labelsConfiguration,
+      author,
+      client
+    )
 
     if (labels.length > 0) await addLabels(client, prNumber, labels)
   } catch (error) {

--- a/src/teams.ts
+++ b/src/teams.ts
@@ -1,9 +1,34 @@
-export function getTeamLabel(
+import * as github from '@actions/github'
+import {isUserMemberOfTeam} from './github'
+
+export async function getTeamLabel(
   labelsConfiguration: Map<string, string[]>,
-  author: string
-): string[] {
+  author: string,
+  client?: github.GitHub
+): Promise<string[]> {
   const labels: string[] = []
-  for (const [label, authors] of labelsConfiguration.entries())
-    if (authors.includes(author)) labels.push(label)
+  for (const [label, authors] of labelsConfiguration.entries()) {
+    for (const authorConfig of authors) {
+      if (isTeam(authorConfig)) {
+        const orgUser = getOrgAndUser(authorConfig);
+        if (client && await isUserMemberOfTeam(client, orgUser[0], orgUser[1], author)) {
+          labels.push(label);
+        }
+      } else {
+        if (authors.includes(`@${author}`)) labels.push(label)
+      }
+    }
+  }
+
   return labels
+}
+
+function isTeam(authorConfig: string): boolean {
+  return authorConfig.includes('/')
+}
+
+function getOrgAndUser(authorConfig: string): [string, string] {
+  const orgUser = authorConfig.split('/', 2)
+
+  return [orgUser[0].slice(1), orgUser[1]]
 }


### PR DESCRIPTION
Additionally to usernames, provide the possibility to label PRs created
by users who are members of GitHub teams.