### PR TITLE
Use node 16 instead of 12

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -10,7 +10,7 @@ inputs:
     required: false
     default: '.github/teams.yml'
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'
 branding:
   icon: 'users'


### PR DESCRIPTION
GitHub advises users of your action to update the action to Node 16. As we use and like it, here's the update.

![image](https://user-images.githubusercontent.com/603683/206549545-0400b94e-5500-4100-8b04-fe913bf2e73d.png)

For more information see: [https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/).