### PR TITLE
Add required permissions to workflow example

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,9 @@ on:
   pull_request:
   issues:
 name: team-label
+permissions:
+  contents: read
+  pull-requests: write
 jobs:
   team-labeler:
     runs-on: ubuntu-latest


### PR DESCRIPTION
When the repo actions configuration is hardened, the default permissions only include read permissions, making the action fail. Adding this configuration block fixes this.

Additionnally, even when it works without it, restricting permissions to the strict minimum is good security hygiene, so, everyone should include this permissions statement.