### PR TITLE
feat: ignore case when matching yml configuration to GitHub author

### DIFF
--- a/__tests__/teams.test.ts
+++ b/__tests__/teams.test.ts
@@ -26,6 +26,19 @@ test('Should add team label when the author is found', () => {
   expect(output).toEqual(['LightSide'])
 })
 
+test('Should be able to detect users with different username casings', () => {
+  // Given
+  const author = '@Anakin'
+  const labelGlobs = new Map<string, string[]>()
+  labelGlobs.set('LightSide', ['@Yoda', '@ANAKIN'])
+
+  // When
+  const output = getTeamLabel(labelGlobs, author)
+
+  // Expect
+  expect(output).toEqual(['LightSide'])
+})
+
 test('Should be able to detect when a user is in multiple teams', () => {
   // Given
   const author = '@Anakin'

--- a/src/teams.ts
+++ b/src/teams.ts
@@ -3,7 +3,9 @@ export function getTeamLabel(
   author: string
 ): string[] {
   const labels: string[] = []
-  for (const [label, authors] of labelsConfiguration.entries())
-    if (authors.includes(author)) labels.push(label)
+  for (const [label, authors] of labelsConfiguration.entries()) {
+    if (authors.some(a => a.toLowerCase() === author.toLowerCase()))
+      labels.push(label)
+  }
   return labels
 }


### PR DESCRIPTION
This PR adds support for case-insensitive matching when comparing the github usernames from the yml configuration to the GitHub actual username. 

Coincidentally, I've seen that someone opened [an issue](https://github.com/JulienKode/team-labeler-action/issues/200) for the same feature request.