### PR TITLE
Use Node v20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -21,7 +21,7 @@ outputs:
   team_labels:
     description: 'JSON array of team labels for the author'
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'
 branding:
   icon: 'users'


### PR DESCRIPTION
GH Actions is throwing warnings and yelling at everybody to [migrate off of the EOL'd Node 16 by October](https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/).

This does that.