### PR TITLE
fix: use all teams of organization

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -38,7 +38,7 @@ async function run() {
         teamsRepo !== '' ? {repo: teamsRepo, ref: teamsBranch} : undefined
       )
 
-    const userTeams = await getUserTeams(orgClient)
+    const userTeams = await getUserTeams(orgClient, author)
     const labels: string[] = getTeamLabel(labelsConfiguration, `@${author}`)
     const teamLabels: string[] = userTeams
       .map(userTeam => getTeamLabel(labelsConfiguration, userTeam))


### PR DESCRIPTION
So we tried out v2 with the configuration for teams, and noticed it didn't work - I'm fairly sure this is due to the usage of `.listForAuthenticatedUser()`, which lists the teams for the user the `org-token` belongs to, and not the user that opened the PR.

This PR fixes the problem (tested on our org), but I don't think it's ideal:
- if an organization has a lost of teams, this will do a _lot_ of API calls (could be fixed with an allow list for team names)
- it won't work for teams that are not part of the same org the repo is in (could be fixed with an additional input)


