### PR TITLE
chore(deps-dev): bump undici from 6.24.0 to 8.1.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,6 +14,9 @@ jobs:
     steps:
     - uses: actions/checkout@v6
     - uses: pnpm/action-setup@v6
+    - uses: actions/setup-node@v4
+      with:
+        node-version: 24
     - run: |
         pnpm install
         pnpm all

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -14,6 +14,9 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
       - run: |
           pnpm install
           pnpm test:e2e

--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
       "@octokit/request>@octokit/types": "13.6.1",
       "@octokit/graphql>@octokit/types": "13.6.1",
       "@octokit/endpoint>@octokit/types": "13.6.1",
-      "@octokit/request-error>@octokit/types": "13.6.1"
+      "@octokit/request-error>@octokit/types": "13.6.1",
+      "undici": "8.1.0"
     }
   },
   "dependencies": {
@@ -63,7 +64,7 @@
     "rollup": "4.60.1",
     "tslib": "2.8.1",
     "typescript": "5.9.3",
-    "undici": "6.24.0",
+    "undici": "8.1.0",
     "vitest": "4.1.5"
   }
 }

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
       "@octokit/graphql>@octokit/types": "13.6.1",
       "@octokit/endpoint>@octokit/types": "13.6.1",
       "@octokit/request-error>@octokit/types": "13.6.1",
-      "undici": "8.1.0"
+      "undici": "8.2.0"
     }
   },
   "dependencies": {
@@ -64,7 +64,7 @@
     "rollup": "4.60.1",
     "tslib": "2.8.1",
     "typescript": "5.9.3",
-    "undici": "8.1.0",
+    "undici": "8.2.0",
     "vitest": "4.1.5"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,7 +10,7 @@ overrides:
   '@octokit/graphql>@octokit/types': 13.6.1
   '@octokit/endpoint>@octokit/types': 13.6.1
   '@octokit/request-error>@octokit/types': 13.6.1
-  undici: 8.1.0
+  undici: 8.2.0
 
 importers:
 
@@ -69,8 +69,8 @@ importers:
         specifier: 5.9.3
         version: 5.9.3
       undici:
-        specifier: 8.1.0
-        version: 8.1.0
+        specifier: 8.2.0
+        version: 8.2.0
       vitest:
         specifier: 4.1.5
         version: 4.1.5(@types/node@25.5.0)(msw@2.12.10(@types/node@25.5.0)(typescript@5.9.3))(vite@6.4.1(@types/node@25.5.0))
@@ -1241,8 +1241,8 @@ packages:
   undici-types@7.18.2:
     resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
 
-  undici@8.1.0:
-    resolution: {integrity: sha512-E9MkTS4xXLnRPYqxH2e6Hr2/49e7WFDKczKcCaFH4VaZs2iNvHMqeIkyUAD9vM8kujy9TjVrRlQ5KkdEJxB2pw==}
+  undici@8.2.0:
+    resolution: {integrity: sha512-Z+4Hx9GE26Lh9Upwfnc8C7SsrpBPGaM/Gm6kMFtiG7c+5IvQKlXi/t+9x9DrrCh29cww5TSP9YdVaBcnLDs5fQ==}
     engines: {node: '>=22.19.0'}
 
   universal-user-agent@7.0.3:
@@ -1396,17 +1396,17 @@ snapshots:
       '@octokit/plugin-rest-endpoint-methods': 17.0.0(@octokit/core@7.0.6)
       '@octokit/request': 10.0.8
       '@octokit/request-error': 7.1.0
-      undici: 8.1.0
+      undici: 8.2.0
 
   '@actions/http-client@3.0.2':
     dependencies:
       tunnel: 0.0.6
-      undici: 8.1.0
+      undici: 8.2.0
 
   '@actions/http-client@4.0.0':
     dependencies:
       tunnel: 0.0.6
-      undici: 8.1.0
+      undici: 8.2.0
 
   '@actions/io@3.0.2': {}
 
@@ -2490,7 +2490,7 @@ snapshots:
 
   undici-types@7.18.2: {}
 
-  undici@8.1.0: {}
+  undici@8.2.0: {}
 
   universal-user-agent@7.0.3: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,6 +10,7 @@ overrides:
   '@octokit/graphql>@octokit/types': 13.6.1
   '@octokit/endpoint>@octokit/types': 13.6.1
   '@octokit/request-error>@octokit/types': 13.6.1
+  undici: 8.1.0
 
 importers:
 
@@ -68,8 +69,8 @@ importers:
         specifier: 5.9.3
         version: 5.9.3
       undici:
-        specifier: 6.24.0
-        version: 6.24.0
+        specifier: 8.1.0
+        version: 8.1.0
       vitest:
         specifier: 4.1.5
         version: 4.1.5(@types/node@25.5.0)(msw@2.12.10(@types/node@25.5.0)(typescript@5.9.3))(vite@6.4.1(@types/node@25.5.0))
@@ -1240,9 +1241,9 @@ packages:
   undici-types@7.18.2:
     resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
 
-  undici@6.24.0:
-    resolution: {integrity: sha512-lVLNosgqo5EkGqh5XUDhGfsMSoO8K0BAN0TyJLvwNRSl4xWGZlCVYsAIpa/OpA3TvmnM01GWcoKmc3ZWo5wKKA==}
-    engines: {node: '>=18.17'}
+  undici@8.1.0:
+    resolution: {integrity: sha512-E9MkTS4xXLnRPYqxH2e6Hr2/49e7WFDKczKcCaFH4VaZs2iNvHMqeIkyUAD9vM8kujy9TjVrRlQ5KkdEJxB2pw==}
+    engines: {node: '>=22.19.0'}
 
   universal-user-agent@7.0.3:
     resolution: {integrity: sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A==}
@@ -1395,17 +1396,17 @@ snapshots:
       '@octokit/plugin-rest-endpoint-methods': 17.0.0(@octokit/core@7.0.6)
       '@octokit/request': 10.0.8
       '@octokit/request-error': 7.1.0
-      undici: 6.24.0
+      undici: 8.1.0
 
   '@actions/http-client@3.0.2':
     dependencies:
       tunnel: 0.0.6
-      undici: 6.24.0
+      undici: 8.1.0
 
   '@actions/http-client@4.0.0':
     dependencies:
       tunnel: 0.0.6
-      undici: 6.24.0
+      undici: 8.1.0
 
   '@actions/io@3.0.2': {}
 
@@ -2489,7 +2490,7 @@ snapshots:
 
   undici-types@7.18.2: {}
 
-  undici@6.24.0: {}
+  undici@8.1.0: {}
 
   universal-user-agent@7.0.3: {}
 


### PR DESCRIPTION
## Summary

- Bumps `undici` devDependency from 6.24.0 → 8.1.0 (rebases dependabot/npm_and_yarn/undici-8.1.0 onto current master).
- Adds `"undici": "8.1.0"` to `pnpm.overrides` so all transitive copies (in `@actions/github` and `@actions/http-client`) unify at 8.1.0 — without this, the e2e tests in `__tests__/e2e/e2e.test.ts` silently miss because userland v8 stores the global dispatcher under `Symbol(undici.globalDispatcher.2)` while the bundled v6 reads `Symbol(undici.globalDispatcher.1)`.
- Note: `@actions/github` and `@actions/http-client` declare `undici: ^6.23.0`, so the override forces them past their declared range; both only consume undici's `fetch`, which is API-stable across v6→v8.

## Test plan

- [x] `pnpm test` (12/12 pass on Node 24)
- [x] `pnpm test:e2e` (7/7 pass on Node 24 — the regression-sensitive surface for undici)
- [x] `pnpm build`, `pnpm format-check`, `pnpm lint`, `pnpm package` all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)