### PR TITLE
chore(deps): bump js-yaml from 4.2.0 to 5.2.1

### DIFF
--- a/__tests__/e2e/e2e.test.ts
+++ b/__tests__/e2e/e2e.test.ts
@@ -206,6 +206,23 @@ describe('E2E: team-labeler-action', () => {
     expect(stdout()).not.toContain('::error::')
   })
 
+  test('no labels when teams config is empty', async () => {
+    prEvent('Anakin')
+    const pool = mockAgent.get('https://api.github.com')
+    setupConfigHandler(pool, '\n')
+
+    await runAction()
+    await vi.waitFor(
+      () => {
+        expect(fs.readFileSync(outputPath, 'utf-8')).toContain('team_labels')
+      },
+      {timeout: 5000}
+    )
+
+    expect(JSON.parse(parseOutput(outputPath).team_labels)).toEqual([])
+    expect(stdout()).not.toContain('::error::')
+  })
+
   test('labels issue when issue author matches config', async () => {
     issueEvent('Anakin')
     let postedLabels: {labels: string[]} | undefined

--- a/package.json
+++ b/package.json
@@ -46,20 +46,19 @@
   "dependencies": {
     "@actions/core": "3.0.1",
     "@actions/github": "9.1.1",
-    "js-yaml": "4.2.0"
+    "js-yaml": "5.2.1"
   },
   "devDependencies": {
     "@eslint/js": "10.0.1",
     "@rollup/plugin-commonjs": "29.0.3",
     "@rollup/plugin-node-resolve": "16.0.3",
     "@rollup/plugin-typescript": "12.3.0",
-    "@types/js-yaml": "4.0.9",
     "@types/node": "26.1.1",
     "@typescript-eslint/eslint-plugin": "8.60.0",
     "@typescript-eslint/parser": "8.63.0",
     "eslint": "10.6.0",
     "globals": "17.7.0",
-    "js-yaml": "4.2.0",
+    "js-yaml": "5.2.1",
     "prettier": "3.9.5",
     "rollup": "4.62.2",
     "tslib": "2.8.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,8 +23,8 @@ importers:
         specifier: 9.1.1
         version: 9.1.1
       js-yaml:
-        specifier: 4.2.0
-        version: 4.2.0
+        specifier: 5.2.1
+        version: 5.2.1
     devDependencies:
       '@eslint/js':
         specifier: 10.0.1
@@ -38,9 +38,6 @@ importers:
       '@rollup/plugin-typescript':
         specifier: 12.3.0
         version: 12.3.0(rollup@4.62.2)(tslib@2.8.1)(typescript@6.0.3)
-      '@types/js-yaml':
-        specifier: 4.0.9
-        version: 4.0.9
       '@types/node':
         specifier: 26.1.1
         version: 26.1.1
@@ -492,79 +489,66 @@ packages:
     resolution: {integrity: sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.62.2':
     resolution: {integrity: sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.62.2':
     resolution: {integrity: sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.62.2':
     resolution: {integrity: sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.62.2':
     resolution: {integrity: sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.62.2':
     resolution: {integrity: sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==}
     cpu: [loong64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.62.2':
     resolution: {integrity: sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.62.2':
     resolution: {integrity: sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==}
     cpu: [ppc64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.62.2':
     resolution: {integrity: sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.62.2':
     resolution: {integrity: sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.62.2':
     resolution: {integrity: sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.62.2':
     resolution: {integrity: sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.62.2':
     resolution: {integrity: sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.62.2':
     resolution: {integrity: sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==}
@@ -610,9 +594,6 @@ packages:
 
   '@types/estree@1.0.9':
     resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
-
-  '@types/js-yaml@4.0.9':
-    resolution: {integrity: sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==}
 
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
@@ -1010,8 +991,8 @@ packages:
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
-  js-yaml@4.2.0:
-    resolution: {integrity: sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==}
+  js-yaml@5.2.1:
+    resolution: {integrity: sha512-zfLtNfQqxVqq3uaTqSkh4x4hZw3KHobGUA0fJUj4wawW8bsQLTVqpHdXSIzidh7o+4lEW36tANuAGdaFx6Zgnw==}
     hasBin: true
 
   json-buffer@3.0.1:
@@ -1805,8 +1786,6 @@ snapshots:
 
   '@types/estree@1.0.9': {}
 
-  '@types/js-yaml@4.0.9': {}
-
   '@types/json-schema@7.0.15': {}
 
   '@types/node@26.1.1':
@@ -2262,7 +2241,7 @@ snapshots:
 
   isexe@2.0.0: {}
 
-  js-yaml@4.2.0:
+  js-yaml@5.2.1:
     dependencies:
       argparse: 2.0.1
 

--- a/src/github.ts
+++ b/src/github.ts
@@ -49,6 +49,10 @@ export async function getLabelsConfiguration(
     configurationPath,
     externalRepo
   )
+  // js-yaml 5 throws on empty sources, keep treating them as an empty config
+  if (!configurationContent.trim()) {
+    return new Map()
+  }
   const configObject: LabelConfiguration = yaml.load(
     configurationContent
   ) as LabelConfiguration


### PR DESCRIPTION
Supersedes #433 (closed) — the dependabot bump done properly, since js-yaml 5 is a major rewrite.

## What's in here beyond the version bump

- **Removed `@types/js-yaml`** — js-yaml 5 is written in TypeScript and ships its own declarations (`dist/js-yaml.d.ts` via `exports`). DefinitelyTyped tops out at 4.0.9 and types API that v5 removed (`DEFAULT_SCHEMA`, `safeLoad`).
- **Preserved empty-config behavior** — v5's `load()` throws `YAMLException` on empty sources where v4 returned `undefined`. Without a guard, a whitespace-only `teams.yml` would start failing the action. `getLabelsConfiguration` now short-circuits to an empty config, covered by a new e2e test.
- **Lockfile regenerated with the pinned pnpm 10.25.0.**

## Compatibility notes

- The only js-yaml call site (`yaml.load` on the teams config) is unaffected: namespace imports of named exports are supported in v5, and `load` keeps its `(string, options?) => unknown` signature.
- v5's default schema is now strict YAML 1.2 `CORE_SCHEMA` (no `!!merge`, no implicit timestamps). The documented config shape (label → quoted `'@user'` strings/lists) parses identically under both versions — verified by comparing `yaml.load` output on 4.2.0 and 5.2.1 for `.github/teams.yml` and representative configs.
- Behavior change accepted: a **comment-only** config file now fails with a clear `YAMLException` (v4 silently produced zero labels).
- Consumers pick up js-yaml 5 when the next release is cut with a rebuilt `dist/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)